### PR TITLE
Fix and add test(s) in accounts app

### DIFF
--- a/sistema_reportes_ppda/accounts/tests/test_permissions.py
+++ b/sistema_reportes_ppda/accounts/tests/test_permissions.py
@@ -3,14 +3,20 @@ from rest_framework import status
 from django.urls import reverse
 from accounts.models import CustomUser
 from management.models import Body
+from custom_permissions import SUPERINTENDENCIA_DEL_MEDIO_AMBIENTE
 
 
 class UserPermissionsTestCase(APITestCase):
     def setUp(self):
         self.superuser = self._create_superuser()
 
-        self.body = Body.objects.create(
-            name="SEREMI TEST",
+        self.body_sma = Body.objects.create(
+            name=SUPERINTENDENCIA_DEL_MEDIO_AMBIENTE,
+            created_by=self.superuser
+        )
+        
+        self.body_other = Body.objects.create(
+            name="Carabineros de Chile",
             created_by=self.superuser
         )
 
@@ -19,7 +25,7 @@ class UserPermissionsTestCase(APITestCase):
             password="test123",
             email="usuario@test.cl",
             rut="12345678-5",
-            body=self.body
+            body=self.body_other
         )
 
         self.user_sma = CustomUser.objects.create_user(
@@ -27,7 +33,7 @@ class UserPermissionsTestCase(APITestCase):
             password="test123",
             email="sma@test.cl",
             rut="11111111-1",
-            body=self.body,
+            body=self.body_sma,
             is_staff=True
         )
 

--- a/sistema_reportes_ppda/accounts/tests/test_register.py
+++ b/sistema_reportes_ppda/accounts/tests/test_register.py
@@ -36,6 +36,21 @@ class RegisterUserAPITestCase(APITestCase):
         response = self.client.post(self.url, data)
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         self.assertTrue(CustomUser.objects.filter(username="usuario1").exists())
+        
+    def test_register_invalid_rut(self):
+        """Debe rechazar el intento de registro por tener RUT inválido."""
+        data = {
+            "username": "usuario1",
+            "password": "ClaveSegura123",
+            "email": "usuario1@test.cl",
+            "rut": "12345678-9",  # Invalid RUT
+            "first_name": "Juan",
+            "last_name": "Pérez",
+            "body": self.body.id
+        }
+        response = self.client.post(self.url, data)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertFalse(CustomUser.objects.filter(username="usuario1").exists())
 
     def test_register_user_with_duplicate_rut_fails(self):
         """Debe fallar si el RUT ya existe."""


### PR DESCRIPTION
En los tests de users, había que crear un usuario del SMA y un usuario de cualquier otro body, me pareció que esto no estaba pasando porque se creaba un body con nombre "SEREMI TEST" que era asignado a ambos, pero debería estar asignado uno a "SUPERINTENDENCIA DEL MEDIO AMBIENTE" porque el validador de is_sma revisa ese nombre.

Rodrigo, como tú habías implementado estos tests quería dejarte a tí como reviewer en caso de que haya existido algo que no haya entendido de la implementación original.

Por otro lado, agregué un test adicional para testear que los RUTs inválidos no permiten la creación de un usuario.